### PR TITLE
Change base image to wip-discord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sourcecred/sourcecred:dev
+FROM sourcecred/sourcecred:wip-discord
 # docker build -t cred-action .
 COPY ./scripts/entrypoint.sh /entrypoint.sh
 COPY ./scripts/pull_request.sh /pull_request.sh


### PR DESCRIPTION
Corresponds to an experiment at:
https://github.com/sourcecred/sourcecred/tree/discord

Deployed as:
[`sourcecred/sourcecred:wip-discord`](https://hub.docker.com/r/sourcecred/sourcecred/tags)