### PR TITLE
Removing project github load in favor of project file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ or continue reading for a basic example.
 ## Usage
 
 This is under development, and currently hosted at vsoch (future will be at
-sourcecred organization).
+sourcecred organization). The suggested best practice is to use a project file,
+which should define the users, plugins, and plugin details (e.g., repositories) 
+to run sourcecred on. This is the `project-file` variable. 
+Within the file, you'll also have defined a project id, something like this:
+
+```json
+    "id": "@sourcecred",
+```
+
+And this is the `project` id. Both are shown below in entirety, and required
+for the action to run.
 
 ```yaml
 uses: vsoch/cred-action@master

--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,14 @@ inputs:
     default: "master"
   project:
     description: >
-      The project id (e.g., @sourcecred), must match a project id in any
-      provided project files.
+      A GitHub project alias (e.g., @sourcecred), meaning an organization or
+      full repository. This variable is only used if project-file (suggested)
+      is not provided. 
     default: "@${{ github.repository }}"
+    required: true
   project-file: 
     description: 'the path to a file containing a project config'
-    default: null
-    required: false
+    required: true
   scores-json:
     description: 'the relative path to save the scores.json. Defaults to scores.json'
     default: "scores.json"

--- a/scripts/build_static_site.sh
+++ b/scripts/build_static_site.sh
@@ -42,7 +42,6 @@ parse_args() {
     target=
     weights=
     repos=( )
-    projects=( )
     project_files=( )
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -61,11 +60,6 @@ parse_args() {
                 shift
                 if [ $# -eq 0 ]; then die 'missing value for --weights'; fi
                 weights="$1"
-                ;;
-            --project)
-                shift
-                if [ $# -eq 0 ]; then die 'missing value for --project'; fi
-                projects+=( "$1" )
                 ;;
             --project-file)
                 shift
@@ -103,27 +97,19 @@ build() {
     sourcecred_data="$(mktemp -d --suffix ".sourcecred-data")"
     export SOURCECRED_DIRECTORY="${sourcecred_data}"
 
-    if [ "${#projects[@]}" -ne 0 ]; then
-        local weightsStr=""
-        if [ -n "${weights}" ]; then
-            weightsStr="--weights ${weights}"
-        fi
-        for project in "${projects[@]}"; do
-            NODE_PATH="/code/node_modules${NODE_PATH:+:${NODE_PATH}}" \
-                node /code/bin/sourcecred.js load "${project}" $weightsStr
-        done
+    # Load project files (required)
+    if [ "${#project_files[@]}" -eq 0 ]; then
+        die 'project-file is required.'
     fi
 
-    if [ "${#project_files[@]}" -ne 0 ]; then
-        local weightsStr=""
-        if [ -n "${weights}" ]; then
-            weightsStr="--weights ${weights}"
-        fi
-        for project_file in "${project_files[@]}"; do
-            NODE_PATH="/code/node_modules${NODE_PATH:+:${NODE_PATH}}" \
-                node /code/bin/sourcecred.js load --project "${project_file}" $weightsStr
-        done
+    local weightsStr=""
+    if [ -n "${weights}" ]; then
+        weightsStr="--weights ${weights}"
     fi
+    for project_file in "${project_files[@]}"; do
+        NODE_PATH="/code/node_modules${NODE_PATH:+:${NODE_PATH}}" \
+            node /code/bin/sourcecred.js load --project "${project_file}" $weightsStr
+    done
 
     # Do we need to be in sourcecred directory here?
     cd /code

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,12 +13,20 @@ if [ -z "${SC_TARGET}" ]; then
    SC_TARGET="${GITHUB_WORKSPACE}/docs"        
 fi
 COMMAND="${COMMAND} --target ${SC_TARGET}"
-COMMAND="${COMMAND} --project ${SC_PROJECT}"
 
-if [ ! -z "${SC_PROJECT_FILE}" ]; then
-    COMMAND="${COMMAND} --project-file ${GITHUB_WORKSPACE}/${SC_PROJECT_FILE}"
+# Project file and if are both required for generation!
+# The action requires, but we have the double check here for a fallback
+if [ -z "${SC_PROJECT_FILE}" ]; then
+    echo "Project file (project-file) is required"
+    exit 1
 fi
+if [ -z "${SC_PROJECT}" ]; then
+    echo "Project identifier (project) is required"
+    exit 1
+fi
+COMMAND="${COMMAND} --project-file ${GITHUB_WORKSPACE}/${SC_PROJECT_FILE}"
 
+# Weights are not required, added if defined
 if [ ! -z "${SC_WEIGHTS}" ]; then
     COMMAND="${COMMAND} --weights ${GITHUB_WORKSPACE}/${SC_WEIGHTS}"
 fi


### PR DESCRIPTION
This pull request will remove the "project" (`$SC_PROJECT`) variable from being used as a GitHub alias to load - what was happening is that it would load _all_ projects for an organization (sourcecred) regardless of the project file. Instead, now:

 - project-file is required, and refers to the combined.json in sourcecred/cred
 - project refers to the "id" in this file

The action was run successfully [here](https://github.com/vsoch/sourcecred-cred/pull/12) and note that the failure isn't for the sourcecred generation, but because the github-actions bot is not allowed to update .github/workflow files. We can actually throw that PR away because we don't need it.

After this fix, my suggestions for next steps:

 - @wchargin can update https://github.com/vsoch/sourcecred-cred/pull/9 so that we don't exhaust the API limit for GitHub. This should allow us to test his changes!
 - Then we can continue as discussed before, next adding the cache and testing again.

I hope that by way of opening a PR here for discussion instead of merging I am doing a tiny bit better than my last effort... baby steps! I'm also excited about the idea of an interface to generate a project file, but we can discuss that later.

Signed-off-by: vsoch <vsochat@stanford.edu>