### PR TITLE
Adding test workflow to emulate GitHub actions

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "sourcecred/project",
+    "version": "0.3.0"
+  },
+  {
+    "discourseServer": null,
+    "id": "@sourcecred",
+    "identities": [],
+    "repoIds": [
+      {
+        "name": "widgets",
+        "owner": "sourcecred"
+      },
+      {
+        "name": "sourcecred-action",
+        "owner": "sourcecred"
+      }
+    ]
+  }
+]

--- a/.github/weights.json
+++ b/.github/weights.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "sourcecred/weights",
+    "version": "0.2.0"
+  },
+  {
+    "edgeWeights": {
+      "E\u0000sourcecred\u0000github\u0000AUTHORS\u0000": {
+        "backwards": 1,
+        "forwards": 0.0625
+      },
+      "E\u0000sourcecred\u0000github\u0000HAS_PARENT\u0000": {
+        "backwards": 0.25,
+        "forwards": 0.0625
+      },
+      "E\u0000sourcecred\u0000github\u0000MERGED_AS\u0000": {
+        "backwards": 0,
+        "forwards": 0
+      },
+      "E\u0000sourcecred\u0000github\u0000REACTS\u0000HOORAY\u0000": {
+        "backwards": 0,
+        "forwards": 2
+      }
+    },
+    "nodeWeights": {
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001544\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001545\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001546\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001547\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001548\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001549\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001550\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001551\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001552\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001553\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001554\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001555\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000sourcecred\u0000sourcecred\u00001556\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000COMMENT\u0000": 1,
+      "N\u0000sourcecred\u0000github\u0000COMMIT\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000ISSUE\u0000": 4,
+      "N\u0000sourcecred\u0000github\u0000PULL\u0000": 16,
+      "N\u0000sourcecred\u0000github\u0000REPO\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000REVIEW\u0000": 8,
+      "N\u0000sourcecred\u0000github\u0000USERLIKE\u0000BOT\u0000": 0,
+      "N\u0000sourcecred\u0000github\u0000USERLIKE\u0000USER\u0000": 0,
+      "N\u0000sourcecred\u0000identity\u0000": 0
+    }
+  }
+]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,67 @@
+name: Main testing workflow
+on: [pull_request]
+
+env:
+
+  # name of docker image
+  image: cred-action
+
+  # repository to checkout to test container
+  repository: vsoch/sourcecred-cred
+
+  # subfolder to clone action to build Docker container
+  builddir: _build
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v2
+      with:
+        path: '${{ env.builddir }}'
+    - name: Build action container
+      env:
+        builddir: '${{ env.builddir }}'
+        image: '${{ env.image }}'
+      run: cd ${builddir} && docker build -t "${image}" .
+    - name: Checkout testing repository
+      uses: actions/checkout@v2
+      with:
+        repository: '${{ env.repository }}'
+
+    # These envars are what would be set by the user in the workflow
+    - name: Test Action with Container
+      env:
+
+        # project-file
+        INPUT_PROJECT_FILE: projects/combined.json
+
+        # project identifier
+        INPUT_PROJECT: '@sourcecred'
+
+        # branch-against
+        INPUT_BRANCH_AGAINST: "master"
+
+        # scores-json
+        INPUT_SCORES_JSON: scores.json
+
+        # weights
+        INPUT_WEIGHTS: weights.json
+
+        # target
+        INPUT_TARGET: docs
+
+        # automated (not relevant since test run is set)
+        INPUT_AUTOMATED: false
+        INPUT_TEST_RUN: false
+
+        # github workspace would normally be honored in container
+        GITHUB_WORKSPACE: /github/workspace
+
+        image: '${{ env.image }}'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      run: docker run --workdir /github/workspace --rm -e token -e INPUT_PROJECT_FILE -e INPUT_TARGET -e INPUT_PROJECT -e INPUT_AUTOMATED -e INPUT_TEST_RUN -e INPUT_BRANCH_AGAINST -e INPUT_SCORES_JSON -e INPUT_WEIGHTS -e SOURCECRED_GITHUB_TOKEN -e GITHUB_TOKEN -e HOME -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e GITHUB_ACTIONS=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "${PWD}/":"/github/workspace" "${image}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,54 +1,20 @@
 name: Main testing workflow
 on: [pull_request]
 
-env:
-
-  # name of docker image
-  image: cred-action
-
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v2
-    - name: Build action container
-      env:
-        image: '${{ env.image }}'
-      run: docker build -t "${image}" .
-
-    # These envars are what would be set by the user in the workflow
-    - name: Test Action with Container
-      env:
-
-        # project-file
-        INPUT_PROJECT_FILE: .github/github.json
-
-        # project identifier
-        INPUT_PROJECT: '@sourcecred'
-
-        # branch-against
-        INPUT_BRANCH_AGAINST: "master"
-
-        # scores-json
-        INPUT_SCORES_JSON: scores.json
-
-        # weights
-        INPUT_WEIGHTS: .github/weights.json
-
-        # target
-        INPUT_TARGET: docs
-
-        # automated (not relevant since test run is set)
-        INPUT_AUTOMATED: false
-        INPUT_TEST_RUN: true
-
-        # github workspace would normally be honored in container
-        GITHUB_WORKSPACE: /github/workspace
-
-        image: '${{ env.image }}'
-        token: ${{ secrets.GITHUB_TOKEN }}
-        SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      run: docker run --workdir /github/workspace --rm -e token -e INPUT_PROJECT_FILE -e INPUT_TARGET -e INPUT_PROJECT -e INPUT_AUTOMATED -e INPUT_TEST_RUN -e INPUT_BRANCH_AGAINST -e INPUT_SCORES_JSON -e INPUT_WEIGHTS -e SOURCECRED_GITHUB_TOKEN -e GITHUB_TOKEN -e HOME -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e GITHUB_ACTIONS=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "${PWD}/":"/github/workspace" "${image}"
+    - name: Test GitHub Action
+      uses: ./
+      env: 
+        token: ${{ secrets.GITHUB_TOKEN }} 
+      with: 
+        project: "@sourcecred" 
+        project-file: .github/github.json 
+        weights: .github/weights.json 
+        branch-against: master 
+        automated: true 
+        test-run: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,36 +6,23 @@ env:
   # name of docker image
   image: cred-action
 
-  # repository to checkout to test container
-  repository: vsoch/sourcecred-cred
-
-  # subfolder to clone action to build Docker container
-  builddir: _build
-
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v2
-      with:
-        path: '${{ env.builddir }}'
     - name: Build action container
       env:
-        builddir: '${{ env.builddir }}'
         image: '${{ env.image }}'
-      run: cd ${builddir} && docker build -t "${image}" .
-    - name: Checkout testing repository
-      uses: actions/checkout@v2
-      with:
-        repository: '${{ env.repository }}'
+      run: docker build -t "${image}" .
 
     # These envars are what would be set by the user in the workflow
     - name: Test Action with Container
       env:
 
         # project-file
-        INPUT_PROJECT_FILE: projects/combined.json
+        INPUT_PROJECT_FILE: .github/github.json
 
         # project identifier
         INPUT_PROJECT: '@sourcecred'
@@ -47,14 +34,14 @@ jobs:
         INPUT_SCORES_JSON: scores.json
 
         # weights
-        INPUT_WEIGHTS: weights.json
+        INPUT_WEIGHTS: .github/weights.json
 
         # target
         INPUT_TARGET: docs
 
         # automated (not relevant since test run is set)
         INPUT_AUTOMATED: false
-        INPUT_TEST_RUN: false
+        INPUT_TEST_RUN: true
 
         # github workspace would normally be honored in container
         GITHUB_WORKSPACE: /github/workspace

--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ with:
 The project id is given to the scores function, and should correspond with any project
 ids referenced in the weights or projects configuration files.
 
+## Variables
+
+A detailed description of all variables is provided in the table below.
+
+| Name           | Description                                          | Required | Default                  |
+| ---------------|------------------------------------------------------|----------|--------------------------|
+| automated      | Push changes to the target branch, otherwise open PR | false    | false                    |
+| branch-against | Push or open PR against this branch                  | false    | master                   |
+| project        | The project identifier to use with sourcecred scores | true     | @${{ github.repository }}|
+| project-file   | The path to a file containing a project config       | true     |                          |
+| scores-json    | Relative path to save the scores.json                | false    | scores.json              |
+| target         | An empty directory into which to build the site      | false    | docs                     |
+| test-run       | Don't open a PR or push to a branch (just run)       | false    | false                    |
+| weights        | Path to a json file that contains weights config     | false    | null                     |
+| token          | Auth token to fetch the repository                   | false    | ${{ github.token }}      |
+
+
+Booleans (true, false) should be lowercase strings for consistency.
+
 ## Development
 
 ### Design

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
   target:
     description: 'an empty directory into which to build the site'
     required: false
+    default: docs
+  test-run:
+    description: "Don't open a pull request or push to a branch, this is a test run"
+    default: false
   weights:
     description: 'path to a json file which contains a weights configuration.'
     default: null
@@ -43,12 +47,9 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    SC_TARGET: ${{ inputs.target }}
-    SC_PROJECT_FILE: ${{ inputs.project-file }}
-    SC_PROJECT: ${{ inputs.project }}
-    SC_AUTOMATED: ${{ inputs.automated }}
-    SC_BRANCH_AGAINST: ${{ inputs.branch-against }}
-    SC_SCORES_JSON: ${{ inputs.scores-json }}
-    SC_WEIGHTS: ${{ inputs.weights }}
+    INPUT_BRANCH_AGAINST: ${{ inputs.branch-against }}
+    INPUT_PROJECT_FILE: ${{ inputs.project-file }}
+    INPUT_SCORES_JSON: ${{ inputs.scores-json }}
+    INPUT_TEST_RUN: ${{ inputs.test-run }}
     SOURCECRED_GITHUB_TOKEN: ${{ inputs.token }}
     GITHUB_TOKEN: ${{ inputs.token }}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,29 +6,28 @@ set -o pipefail
 # and customizes the entrypoint based on what the user has provided.
 # We derive variables from the environment instead of command line
 
-COMMAND="/bin/bash /build_static_site.sh"
+# Tell the user files found immediately
+echo "Found files in workspace:"
+ls
 
-# Target is required, project has a default
-if [ -z "${SC_TARGET}" ]; then
-   SC_TARGET="${GITHUB_WORKSPACE}/docs"        
-fi
-COMMAND="${COMMAND} --target ${SC_TARGET}"
+COMMAND="/bin/bash /build_static_site.sh"
+COMMAND="${COMMAND} --target ${INPUT_TARGET}"
 
 # Project file and if are both required for generation!
 # The action requires, but we have the double check here for a fallback
-if [ -z "${SC_PROJECT_FILE}" ]; then
+if [ -z "${INPUT_PROJECT_FILE}" ]; then
     echo "Project file (project-file) is required"
     exit 1
 fi
-if [ -z "${SC_PROJECT}" ]; then
+if [ -z "${INPUT_PROJECT}" ]; then
     echo "Project identifier (project) is required"
     exit 1
 fi
-COMMAND="${COMMAND} --project-file ${GITHUB_WORKSPACE}/${SC_PROJECT_FILE}"
+COMMAND="${COMMAND} --project-file ${INPUT_PROJECT_FILE}"
 
 # Weights are not required, added if defined
-if [ ! -z "${SC_WEIGHTS}" ]; then
-    COMMAND="${COMMAND} --weights ${GITHUB_WORKSPACE}/${SC_WEIGHTS}"
+if [ ! -z "${INPUT_WEIGHTS}" ]; then
+    COMMAND="${COMMAND} --weights ${INPUT_WEIGHTS}"
 fi
 
 # Show the user where we are
@@ -39,7 +38,7 @@ ls
 # Clean up any previous runs (deployed in docs folder)
 # This command needs to be run relative to sourcecred respository
 # that is located at the WORKDIR /code
-rm -rf "${SC_TARGET}"
+rm -rf "${INPUT_TARGET}"
 echo "${COMMAND}"
 ${COMMAND}
 
@@ -49,19 +48,26 @@ ls
 # This interacts with node sourcecred.js
 # Load it twice so we can access the scores -- it's a hack, pending real instance system
 # Note from @vsoch: these variable names aren't consistent - the project here referes to the project file.
-LOAD_COMMAND="node /code/bin/sourcecred.js load --project ${GITHUB_WORKSPACE}/${SC_PROJECT_FILE}"
-if [ ! -z "${SC_WEIGHTS}" ]; then
-    LOAD_COMMAND="${LOAD_COMMAND} --weights ${GITHUB_WORKSPACE}/${SC_WEIGHTS}"
+LOAD_COMMAND="node /code/bin/sourcecred.js load --project ${INPUT_PROJECT_FILE}"
+if [ ! -z "${INPUT_WEIGHTS}" ]; then
+    LOAD_COMMAND="${LOAD_COMMAND} --weights ${INPUT_WEIGHTS}"
 fi
 echo "$LOAD_COMMAND"
 ${LOAD_COMMAND}
-node /code/bin/sourcecred.js scores "${SC_PROJECT}" | python3 -m json.tool > "${GITHUB_WORKSPACE}/${SC_SCORES_JSON}"
+node /code/bin/sourcecred.js scores "${INPUT_PROJECT}" | python3 -m json.tool > "${INPUT_SCORES_JSON}"
 
-# Now we want to interact with the GitHub repository
-# The GitHub workspace has the root of the repository
-cd "${GITHUB_WORKSPACE}"
-echo "Found files in workspace:"
-ls
+# Automated means that we push to a branch, otherwise we open a pull request
+if [ "${INPUT_AUTOMATED}" == "true" ]; then
+    echo "Automated PR requested"
+    UPDATE_BRANCH="${INPUT_BRANCH_AGAINST}"
+else
+    UPDATE_BRANCH="update/sourcecred-cred-$(date '+%Y-%m-%d')"
+fi
+
+if [ "${INPUT_TEST_RUN}" == "true" ]; then
+    printf "Test run detected, exiting with 0.\n"
+    exit 0
+fi
 
 echo "GitHub Actor: ${GITHUB_ACTOR}"
 git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -69,29 +75,21 @@ git branch
 git config --global user.name "github-actions"
 git config --global user.email "github-actions@users.noreply.github.com"
 
-# Automated means that we push to a branch, otherwise we open a pull request
-if [ "${SC_AUTOMATED}" == "true" ]; then
-    echo "Automated PR requested"
-    UPDATE_BRANCH="${SC_BRANCH_AGAINST}"
-else
-    UPDATE_BRANCH="update/sourcecred-cred-$(date '+%Y-%m-%d')"
-fi
-
 export UPDATE_BRANCH
 echo "Branch to update is ${UPDATE_BRANCH}"
 git checkout -b ${UPDATE_BRANCH}
 git branch
 
-if [ "${SC_AUTOMATED}" == "true" ]; then
+if [ "${INPUT_AUTOMATED}" == "true" ]; then
     git pull origin "${UPDATE_BRANCH}" || echo "Branch not yet on remote"
-    git add "${SC_TARGET}/*"
-    git add "${SC_SCORES_JSON}"
-    git commit -m "Automated deployment to update cred in ${SC_TARGET} $(date '+%Y-%m-%d')"
+    git add "${INPUT_TARGET}/*"
+    git add "${INPUT_SCORES_JSON}"
+    git commit -m "Automated deployment to update cred in ${INPUT_TARGET} $(date '+%Y-%m-%d')"
     git push origin "${UPDATE_BRANCH}"
 else
-    git add "${SC_TARGET}/*"
-    git add "${SC_SCORES_JSON}"
-    git commit -m "Automated deployment to update ${SC_TARGET} static files $(date '+%Y-%m-%d')"
+    git add "${INPUT_TARGET}/*"
+    git add "${INPUT_SCORES_JSON}"
+    git commit -m "Automated deployment to update ${INPUT_TARGET} static files $(date '+%Y-%m-%d')"
     git push origin "${UPDATE_BRANCH}"
     /bin/bash -e /pull_request.sh
 fi

--- a/scripts/pull_request.sh
+++ b/scripts/pull_request.sh
@@ -87,14 +87,14 @@ main () {
     fi
     echo "Branch for pull request is ${UPDATE_BRANCH}"
 
-    if [ -z "${SC_BRANCH_AGAINST}" ]; then
-        SC_BRANCH_AGAINST=master
+    if [ -z "${INPUT_BRANCH_AGAINST}" ]; then
+        INPUT_BRANCH_AGAINST=master
     fi
-    echo "Pull request will go against ${SC_BRANCH_AGAINST}"
+    echo "Pull request will go against ${INPUT_BRANCH_AGAINST}"
 
     # Ensure we have a GitHub token
     check_credentials
-    create_pull_request "${UPDATE_BRANCH}" "${SC_BRANCH_AGAINST}"
+    create_pull_request "${UPDATE_BRANCH}" "${INPUT_BRANCH_AGAINST}"
 
 }
 


### PR DESCRIPTION
In addition to adding a github workflow to test building and running the container, I have also added a test-run variable that will ensure that we skip over pushing to a branch directly or opening a PR.
Since the test required definition of container environment variables, and since we were hugely redundant in re-defining many, I cleaned this up so that most variables can use the automatically generated INPUT_<name>. For variables with dashes, (-) I still needed to provide a custom environment variable, along with envars that sourcecred expects (e.g., the GitHub token). I also added a nice table of workflow variables to the README.md so that it's explicitly clear.

This will address #13 and close #12. I suspect I'll need to run this more than once to get everything working properly, and I'll flag the PR ready for review when I'm done working.

Signed-off-by: vsoch <vsochat@stanford.edu>